### PR TITLE
Fix #17: 日記の入力欄のサイズを適切に調整

### DIFF
--- a/app/src/main/java/net/chasmine/oneline/ui/components/DiaryForm.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/components/DiaryForm.kt
@@ -77,7 +77,7 @@ fun DiaryForm(
                 onValueChange = onContentChange,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f),
+                    .height(200.dp),
                 placeholder = { Text("今日の一行を記録しましょう...") },
                 label = { Text("きょうの一行") },
                 maxLines = 10


### PR DESCRIPTION
## 概要
issue #17 「日記の入力欄がデカすぎる」を修正しました。

## 変更内容
- `OutlinedTextField`の`weight(1f)`を削除し、`height(200.dp)`に変更
- キーボード表示時の余白を考慮した適切なサイズに調整

## 修正理由
実際に入力するときには下からキーボードが表示されるため、画面下に余白を残すことで使いやすさを向上させました。

## テスト
- [ ] 日記編集画面で入力フィールドが適切なサイズで表示される
- [ ] キーボード表示時に適切な余白が確保される

Closes #17