### PR TITLE
Implement #12: ローカルプッシュ通知機能を実装

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <application
         android:allowBackup="true"
@@ -42,5 +45,9 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/diary_glance_widget_info" />
         </receiver>
+
+        <receiver
+            android:name=".util.NotificationReceiver"
+            android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/net/chasmine/oneline/data/preferences/NotificationPreferences.kt
+++ b/app/src/main/java/net/chasmine/oneline/data/preferences/NotificationPreferences.kt
@@ -1,0 +1,50 @@
+package net.chasmine.oneline.data.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class NotificationPreferences private constructor(context: Context) {
+    
+    companion object {
+        @Volatile
+        private var INSTANCE: NotificationPreferences? = null
+        
+        fun getInstance(context: Context): NotificationPreferences {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: NotificationPreferences(context.applicationContext).also { INSTANCE = it }
+            }
+        }
+        
+        private const val PREFS_NAME = "notification_prefs"
+        private const val KEY_NOTIFICATION_ENABLED = "notification_enabled"
+        private const val KEY_NOTIFICATION_HOUR = "notification_hour"
+        private const val KEY_NOTIFICATION_MINUTE = "notification_minute"
+    }
+    
+    private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    
+    private val _isNotificationEnabled = MutableStateFlow(prefs.getBoolean(KEY_NOTIFICATION_ENABLED, false))
+    val isNotificationEnabled: StateFlow<Boolean> = _isNotificationEnabled
+    
+    private val _notificationHour = MutableStateFlow(prefs.getInt(KEY_NOTIFICATION_HOUR, 20))
+    val notificationHour: StateFlow<Int> = _notificationHour
+    
+    private val _notificationMinute = MutableStateFlow(prefs.getInt(KEY_NOTIFICATION_MINUTE, 0))
+    val notificationMinute: StateFlow<Int> = _notificationMinute
+    
+    fun setNotificationEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_NOTIFICATION_ENABLED, enabled).apply()
+        _isNotificationEnabled.value = enabled
+    }
+    
+    fun setNotificationTime(hour: Int, minute: Int) {
+        prefs.edit()
+            .putInt(KEY_NOTIFICATION_HOUR, hour)
+            .putInt(KEY_NOTIFICATION_MINUTE, minute)
+            .apply()
+        _notificationHour.value = hour
+        _notificationMinute.value = minute
+    }
+}

--- a/app/src/main/java/net/chasmine/oneline/ui/MainActivity.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/MainActivity.kt
@@ -18,6 +18,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import net.chasmine.oneline.data.git.GitRepository
+import net.chasmine.oneline.data.preferences.NotificationPreferences
+import net.chasmine.oneline.util.DiaryNotificationManager
 import net.chasmine.oneline.ui.screens.DiaryEditScreen
 import net.chasmine.oneline.ui.screens.DiaryListScreen
 import net.chasmine.oneline.ui.screens.SettingsScreen
@@ -27,6 +29,10 @@ import net.chasmine.oneline.ui.screens.DiaryEditScreen
 import net.chasmine.oneline.ui.screens.DiaryListScreen
 import net.chasmine.oneline.ui.screens.SettingsScreen
 import net.chasmine.oneline.ui.theme.OneLineTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -36,6 +42,9 @@ class MainActivity : ComponentActivity() {
         val fromWidget = intent.getBooleanExtra("EXTRA_FROM_WIDGET", false)
         val openNewEntry = intent.getBooleanExtra("EXTRA_OPEN_NEW_ENTRY", false)
         val openSettings = intent?.getBooleanExtra("OPEN_SETTINGS", false) ?: false
+
+        // 通知設定を初期化
+        initializeNotifications()
 
         setContent {
             OneLineTheme {
@@ -49,6 +58,20 @@ class MainActivity : ComponentActivity() {
                         openSettings = openSettings
                     )
                 }
+            }
+        }
+    }
+
+    private fun initializeNotifications() {
+        CoroutineScope(Dispatchers.IO).launch {
+            val notificationPrefs = NotificationPreferences.getInstance(this@MainActivity)
+            val isEnabled = notificationPrefs.isNotificationEnabled.first()
+            
+            if (isEnabled) {
+                val hour = notificationPrefs.notificationHour.first()
+                val minute = notificationPrefs.notificationMinute.first()
+                val notificationManager = DiaryNotificationManager(this@MainActivity)
+                notificationManager.scheduleDaily(hour, minute)
             }
         }
     }

--- a/app/src/main/java/net/chasmine/oneline/ui/components/NotificationSettingsSection.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/components/NotificationSettingsSection.kt
@@ -1,0 +1,163 @@
+package net.chasmine.oneline.ui.components
+
+import android.Manifest
+import android.app.TimePickerDialog
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import net.chasmine.oneline.data.preferences.NotificationPreferences
+import net.chasmine.oneline.util.DiaryNotificationManager
+
+@Composable
+fun NotificationSettingsSection() {
+    val context = LocalContext.current
+    val notificationPrefs = remember { NotificationPreferences.getInstance(context) }
+    val notificationManager = remember { DiaryNotificationManager(context) }
+    
+    val isNotificationEnabled by notificationPrefs.isNotificationEnabled.collectAsState()
+    val notificationHour by notificationPrefs.notificationHour.collectAsState()
+    val notificationMinute by notificationPrefs.notificationMinute.collectAsState()
+    
+    var showPermissionDialog by remember { mutableStateOf(false) }
+    
+    // 通知権限のリクエスト
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            notificationPrefs.setNotificationEnabled(true)
+            notificationManager.scheduleDaily(notificationHour, notificationMinute)
+        } else {
+            showPermissionDialog = true
+        }
+    }
+    
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // 通知ON/OFF設定
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "日記リマインダー",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = "毎日決まった時間に日記を書くリマインダーを受け取る",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = isNotificationEnabled,
+                    onCheckedChange = { enabled ->
+                        if (enabled) {
+                            // 通知権限をチェック
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                when (ContextCompat.checkSelfPermission(
+                                    context,
+                                    Manifest.permission.POST_NOTIFICATIONS
+                                )) {
+                                    PackageManager.PERMISSION_GRANTED -> {
+                                        notificationPrefs.setNotificationEnabled(true)
+                                        notificationManager.scheduleDaily(notificationHour, notificationMinute)
+                                    }
+                                    else -> {
+                                        permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                                    }
+                                }
+                            } else {
+                                notificationPrefs.setNotificationEnabled(true)
+                                notificationManager.scheduleDaily(notificationHour, notificationMinute)
+                            }
+                        } else {
+                            notificationPrefs.setNotificationEnabled(false)
+                            notificationManager.cancelDaily()
+                        }
+                    }
+                )
+            }
+            
+            // 時間設定
+            if (isNotificationEnabled) {
+                Divider()
+                
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            TimePickerDialog(
+                                context,
+                                { _, hour, minute ->
+                                    notificationPrefs.setNotificationTime(hour, minute)
+                                    notificationManager.cancelDaily()
+                                    notificationManager.scheduleDaily(hour, minute)
+                                },
+                                notificationHour,
+                                notificationMinute,
+                                true
+                            ).show()
+                        }
+                        .padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column {
+                        Text(
+                            text = "通知時刻",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = "タップして時刻を変更",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Text(
+                        text = String.format("%02d:%02d", notificationHour, notificationMinute),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+    
+    // 権限拒否時のダイアログ
+    if (showPermissionDialog) {
+        AlertDialog(
+            onDismissRequest = { showPermissionDialog = false },
+            title = { Text("通知権限が必要です") },
+            text = { 
+                Text("日記リマインダーを受け取るには、通知権限を許可してください。設定アプリから権限を有効にできます。") 
+            },
+            confirmButton = {
+                TextButton(onClick = { showPermissionDialog = false }) {
+                    Text("OK")
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/SettingScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/SettingScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import net.chasmine.oneline.ui.viewmodels.SettingsViewModel
+import net.chasmine.oneline.ui.components.NotificationSettingsSection
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -265,6 +266,17 @@ fun SettingsScreen(
                             Text("まずリポジトリを検証してください")
                         }
                     }
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    // 通知設定セクション
+                    Text(
+                        text = "🔔 通知設定",
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier.padding(bottom = 16.dp)
+                    )
+
+                    NotificationSettingsSection()
                 }
 
                 if (uiState is SettingsViewModel.UiState.Saving) {

--- a/app/src/main/java/net/chasmine/oneline/util/NotificationManager.kt
+++ b/app/src/main/java/net/chasmine/oneline/util/NotificationManager.kt
@@ -1,0 +1,117 @@
+package net.chasmine.oneline.util
+
+import android.app.AlarmManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import net.chasmine.oneline.R
+import net.chasmine.oneline.ui.MainActivity
+import java.util.*
+
+class DiaryNotificationManager(private val context: Context) {
+    
+    companion object {
+        private const val CHANNEL_ID = "diary_reminder"
+        private const val NOTIFICATION_ID = 1001
+        private const val REQUEST_CODE = 1002
+    }
+    
+    init {
+        createNotificationChannel()
+    }
+    
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = "日記リマインダー"
+            val descriptionText = "日記を書くリマインダー通知"
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+                description = descriptionText
+            }
+            
+            val notificationManager: NotificationManager =
+                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+    
+    fun scheduleDaily(hour: Int, minute: Int) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(context, NotificationReceiver::class.java)
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        
+        val calendar = Calendar.getInstance().apply {
+            timeInMillis = System.currentTimeMillis()
+            set(Calendar.HOUR_OF_DAY, hour)
+            set(Calendar.MINUTE, minute)
+            set(Calendar.SECOND, 0)
+            
+            // 今日の指定時刻が過ぎていたら明日に設定
+            if (timeInMillis <= System.currentTimeMillis()) {
+                add(Calendar.DAY_OF_MONTH, 1)
+            }
+        }
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                calendar.timeInMillis,
+                pendingIntent
+            )
+        } else {
+            alarmManager.setExact(
+                AlarmManager.RTC_WAKEUP,
+                calendar.timeInMillis,
+                pendingIntent
+            )
+        }
+    }
+    
+    fun cancelDaily() {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(context, NotificationReceiver::class.java)
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        
+        alarmManager.cancel(pendingIntent)
+    }
+    
+    fun showNotification() {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("今日の一行を書きませんか？")
+            .setContentText("今日はどんな一日でしたか？日記を書いて記録しましょう。")
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+        
+        with(NotificationManagerCompat.from(context)) {
+            notify(NOTIFICATION_ID, notification)
+        }
+    }
+}

--- a/app/src/main/java/net/chasmine/oneline/util/NotificationReceiver.kt
+++ b/app/src/main/java/net/chasmine/oneline/util/NotificationReceiver.kt
@@ -1,0 +1,42 @@
+package net.chasmine.oneline.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import net.chasmine.oneline.data.git.GitRepository
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class NotificationReceiver : BroadcastReceiver() {
+    
+    override fun onReceive(context: Context, intent: Intent) {
+        val notificationManager = DiaryNotificationManager(context)
+        val gitRepository = GitRepository.getInstance(context)
+        
+        // 今日の日記が既に書かれているかチェック
+        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val entry = gitRepository.getEntry(today)
+                if (entry == null || entry.content.isBlank()) {
+                    // 今日の日記がまだ書かれていない場合のみ通知を表示
+                    notificationManager.showNotification()
+                }
+                
+                // 次の日の通知をスケジュール
+                val prefs = context.getSharedPreferences("notification_prefs", Context.MODE_PRIVATE)
+                val hour = prefs.getInt("notification_hour", 20) // デフォルト20時
+                val minute = prefs.getInt("notification_minute", 0) // デフォルト0分
+                notificationManager.scheduleDaily(hour, minute)
+                
+            } catch (e: Exception) {
+                // エラーが発生した場合でも通知を表示
+                notificationManager.showNotification()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要
issue #12 「ローカルプッシュ通知を実装」を完了しました。

## 実装内容

### 新規作成ファイル
- `DiaryNotificationManager`: 通知の作成・スケジュール管理
- `NotificationReceiver`: 通知の受信・処理
- `NotificationPreferences`: 通知設定の保存・管理
- `NotificationSettingsSection`: 設定画面の通知設定UI

### 修正ファイル
- `AndroidManifest.xml`: 通知権限の追加
- `MainActivity.kt`: アプリ起動時の通知設定初期化
- `SettingScreen.kt`: 通知設定セクションの追加

## 機能詳細

### 🔔 通知機能
- 毎日指定時刻（デフォルト20:00）にリマインダー通知を送信
- 既に今日の日記を書いている場合は通知をスキップ
- 通知をタップするとアプリが起動

### ⚙️ 設定機能
- 通知のON/OFF切り替え
- 通知時刻の変更（タイムピッカーで選択）
- Android 13以降の通知権限リクエスト対応

### 🔒 権限管理
- `POST_NOTIFICATIONS`: 通知表示権限
- `SCHEDULE_EXACT_ALARM`: 正確な時刻での通知スケジュール
- `USE_EXACT_ALARM`: 正確なアラーム使用権限

## テスト項目
- [ ] 設定画面で通知ON/OFFが正常に動作する
- [ ] 時刻設定が正常に保存・反映される
- [ ] 通知権限のリクエストが正常に動作する
- [ ] 指定時刻に通知が表示される
- [ ] 既に日記を書いている場合は通知が表示されない
- [ ] 通知をタップしてアプリが起動する

## 注意事項
- Android 13以降では初回起動時に通知権限の許可が必要
- バッテリー最適化の設定によっては通知が遅延する可能性があります

Closes #12