### PR TITLE
Fix #29: Improve screen transition animations for better UX

### DIFF
--- a/app/src/main/java/net/chasmine/oneline/ui/MainActivity.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/MainActivity.kt
@@ -19,6 +19,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
 import net.chasmine.oneline.data.git.GitRepository
 import net.chasmine.oneline.data.repository.RepositoryManager
 import net.chasmine.oneline.data.preferences.SettingsManager
@@ -233,7 +235,31 @@ fun OneLineApp(
 
     NavHost(
         navController = navController, 
-        startDestination = if (isFirstLaunch && !fromWidget) "welcome" else "diary_list"
+        startDestination = if (isFirstLaunch && !fromWidget) "welcome" else "diary_list",
+        enterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { it },
+                animationSpec = tween(300)
+            ) + fadeIn(animationSpec = tween(300))
+        },
+        exitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { -it / 3 },
+                animationSpec = tween(300)
+            ) + fadeOut(animationSpec = tween(300))
+        },
+        popEnterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { -it / 3 },
+                animationSpec = tween(300)
+            ) + fadeIn(animationSpec = tween(300))
+        },
+        popExitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { it },
+                animationSpec = tween(300)
+            ) + fadeOut(animationSpec = tween(300))
+        }
     ) {
         composable("welcome") {
             WelcomeScreen(


### PR DESCRIPTION
## 概要
画面遷移のフェードアニメーションが遅く感じられる問題を解決し、軽快で自然なUXを提供します。

## 変更内容
- デフォルトのフェードアニメーションをスライド + フェードの組み合わせに改善
- アニメーション時間を300msに設定し、軽快な操作感を実現
- 前進・後退それぞれに適切な方向のアニメーションを設定

## 技術的詳細
- `slideInHorizontally` / `slideOutHorizontally` でスライド効果
- `fadeIn` / `fadeOut` で滑らかな透明度変化
- Navigation Composeの推奨実装方法に準拠

## UX改善効果
- 画面の関係性が明確になり、ナビゲーションが直感的に
- 300msの短時間で軽快な操作感を実現
- 一般的な優良アプリと同等のUXを提供

Fixes #29