### PR TITLE
Phase 3: ゲーミフィケーション要素の追加 (#36)

### DIFF
--- a/app/src/main/java/net/chasmine/oneline/ui/screens/CalendarScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/CalendarScreen.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
@@ -100,6 +102,7 @@ fun CalendarScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp)
         ) {
             // 年月の切り替えヘッダー
@@ -206,9 +209,12 @@ fun CalendarGrid(
     
     LazyVerticalGrid(
         columns = GridCells.Fixed(7),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(300.dp), // 固定高を設定してスクロールコンテナとのネストを回避
         verticalArrangement = Arrangement.spacedBy(4.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp)
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        userScrollEnabled = false // 親のColumnでスクロールするため無効化
     ) {
         items(calendarDays) { date ->
             CalendarDay(
@@ -308,6 +314,9 @@ fun DiaryStatisticsSection(
     val totalCount = remember(allEntries) {
         DiaryStatistics.calculateTotalCount(allEntries)
     }
+    val weeklyPattern = remember(allEntries) {
+        DiaryStatistics.getWeeklyPattern(allEntries)
+    }
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -328,12 +337,11 @@ fun DiaryStatisticsSection(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // 2x2のグリッド
+            // 1列目：現在のストリークと最長ストリーク
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                // 現在のストリーク
                 StatisticsItem(
                     modifier = Modifier.weight(1f),
                     label = "現在の連続",
@@ -342,7 +350,6 @@ fun DiaryStatisticsSection(
                     icon = "🔥"
                 )
 
-                // 最長ストリーク
                 StatisticsItem(
                     modifier = Modifier.weight(1f),
                     label = "最長連続",
@@ -354,11 +361,18 @@ fun DiaryStatisticsSection(
 
             Spacer(modifier = Modifier.height(12.dp))
 
+            // 週間パターングラフ（フル幅）
+            WeeklyPatternGraph(
+                pattern = weeklyPattern
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 2列目：今月の投稿数と総投稿数
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                // 今月の投稿数
                 StatisticsItem(
                     modifier = Modifier.weight(1f),
                     label = "今月",
@@ -367,7 +381,6 @@ fun DiaryStatisticsSection(
                     icon = "📅"
                 )
 
-                // 総投稿数
                 StatisticsItem(
                     modifier = Modifier.weight(1f),
                     label = "総投稿数",
@@ -439,6 +452,80 @@ fun StatisticsItem(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
             )
+        }
+    }
+}
+
+@Composable
+fun WeeklyPatternGraph(
+    pattern: List<Boolean>
+) {
+    val days = listOf("月", "火", "水", "木", "金", "土", "日")
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 1.dp
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp)
+        ) {
+            Text(
+                text = "📈 過去7日間",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // グラフ部分
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.Bottom
+            ) {
+                pattern.forEachIndexed { index, hasEntry ->
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        // バー
+                        Box(
+                            modifier = Modifier
+                                .width(24.dp)
+                                .height(if (hasEntry) 40.dp else 8.dp)
+                                .clip(RoundedCornerShape(topStart = 6.dp, topEnd = 6.dp))
+                                .background(
+                                    if (hasEntry)
+                                        MaterialTheme.colorScheme.primary
+                                    else
+                                        MaterialTheme.colorScheme.surfaceVariant
+                                )
+                        )
+
+                        Spacer(modifier = Modifier.height(4.dp))
+
+                        // 曜日ラベル
+                        Text(
+                            text = days[index],
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (hasEntry)
+                                MaterialTheme.colorScheme.primary
+                            else
+                                MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 10.sp
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/net/chasmine/oneline/util/DiaryStatistics.kt
+++ b/app/src/main/java/net/chasmine/oneline/util/DiaryStatistics.kt
@@ -76,4 +76,18 @@ object DiaryStatistics {
     fun calculateTotalCount(entries: List<DiaryEntry>): Int {
         return entries.size
     }
+
+    /**
+     * 過去7日間の投稿パターンを取得
+     * @return 過去7日分の投稿有無（古い日→新しい日の順）
+     */
+    fun getWeeklyPattern(entries: List<DiaryEntry>): List<Boolean> {
+        val today = LocalDate.now()
+        val entryDates = entries.map { it.date }.toSet()
+
+        return (6 downTo 0).map { daysAgo ->
+            val date = today.minusDays(daysAgo.toLong())
+            entryDates.contains(date)
+        }
+    }
 }


### PR DESCRIPTION
## 概要
issue #36 の Phase 3 実装です。カレンダー画面にゲーミフィケーション要素を追加し、日記の投稿実績を視覚化しました。

## 実装内容

### ✅ 1. 統計計算ユーティリティの実装
新規ファイル `DiaryStatistics.kt` を作成し、以下の統計情報を計算する機能を実装：

#### 現在のストリーク（連続日数）
- 今日または昨日から始まる連続投稿日数を計算
- 連続が途切れている場合は0を返す

#### 最長ストリーク
- これまでの最長連続投稿日数を計算
- 全期間の日記データから算出

#### 今月の投稿数
- 現在表示している月の投稿数をカウント
- 月が変わると自動的に再計算

#### 総投稿数
- これまでに書いた日記の総数

#### 週間パターン
- 過去7日間の投稿状況をグラフで可視化
- 投稿がある日は高いバー、ない日は低いバーで表示

### ✅ 2. カレンダー画面に投稿実績セクションを追加
カレンダーグリッドの下部に「📊 投稿実績」セクションを新規追加：

**レイアウト:**
- 統計情報カード4つ（2x2グリッド）
- 過去7日間のグラフ（フル幅）
- Material 3デザインガイドラインに準拠

**表示内容:**
```
┌─────────────┬─────────────┐
│ 🔥 現在の連続 │ 🏆 最長連続  │
│   X日       │   Y日       │
├─────────────┴─────────────┤
│ 📈 過去7日間（バーグラフ） │
├─────────────┬─────────────┤
│ 📅 今月     │ ✨ 総投稿数  │
│  Z投稿      │  W投稿      │
└─────────────┴─────────────┘
```

### ✅ 3. UIコンポーネントの実装

#### DiaryStatisticsSection
- 統計情報全体を表示するコンポーネント
- 全ての日記エントリーを受け取り、統計を計算
- `remember`を使用してパフォーマンス最適化

#### StatisticsItem
- 個々の統計情報を表示するカードコンポーネント
- アイコン、数値、単位、ラベルを表示
- 再利用可能な設計

#### WeeklyPatternGraph
- 過去7日間の投稿パターンをバーグラフで表示
- 投稿あり: 高いバー（primary color）
- 投稿なし: 低いバー（surfaceVariant）

### ✅ 4. クラッシュ修正
**問題**: カレンダー画面を開くとアプリが異常終了

**原因**: `LazyVerticalGrid`がスクロール可能な`Column`の中にネストされていた

**修正内容**:
- `LazyVerticalGrid`に固定高（300.dp）を設定
- `userScrollEnabled = false` を追加して親Columnでスクロール
- Jetpack Composeのネスト制約に準拠

## デザイン詳細

### カラー
- 外側のカード背景: `surfaceVariant`
- 統計カード: `surface` with `elevation 1dp`
- 数値: `primary` color, bold
- ラベル・単位: `onSurfaceVariant`

### タイポグラフィ
- セクションタイトル: `titleMedium`, bold
- アイコン: `24sp`
- 数値: `headlineMedium`, bold
- 単位: `bodySmall`
- ラベル: `bodySmall`

### スペーシング
- カード間: `12dp`
- セクション内パディング: `16dp`
- カード内パディング: `12dp`
- カード角丸: `12dp` / `16dp`

## 技術詳細

### パフォーマンス最適化
```kotlin
val currentStreak = remember(allEntries) {
    DiaryStatistics.calculateCurrentStreak(allEntries)
}
```
- `remember`を使用して不要な再計算を防止
- 依存データが変更された時のみ再計算

### ストリーク計算アルゴリズム
- 現在のストリーク: 今日/昨日から逆順に連続日数をカウント
- 最長ストリーク: 全データをソートして最長の連続区間を検出

### Compose制約への対応
Lazyコンポーネントを別のスクロールコンテナ内に配置することは許可されていないため、
カレンダーグリッドは固定高となり、統計情報を含む全体が親のColumnで
正しくスクロールできるようになりました。

## 変更ファイル
- `CalendarScreen.kt`: 統計情報セクション追加、UIコンポーネント実装、クラッシュ修正
- `DiaryStatistics.kt`: 新規作成（統計計算ロジック）

## コミット履歴
1. Phase 3: ゲーミフィケーション要素の追加 (#36)
2. LazyVerticalGridのネスト問題を修正してクラッシュを解消

## テスト
- [x] ビルド成功（`./gradlew build`）
- [x] 全テストパス（40テスト）
- [x] クラッシュ修正確認
- [ ] 実機での動作確認（予定）

## 次のステップ (Phase 4)
- iOSライクなデザインシステムの構築
- ボトムナビゲーションのSwarm風リデザイン
- 全画面への一貫したデザイン適用

## 関連Issue
Closes #36 (Part 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)