### PR TITLE
ボトムナビゲーションで同じタブを連打した際の不要な画面遷移を防止 (#49)

### DIFF
--- a/app/src/main/java/net/chasmine/oneline/ui/MainActivity.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/MainActivity.kt
@@ -305,17 +305,16 @@ fun OneLineApp(
                 CustomBottomBar(
                     selectedTab = selectedTab,
                     onTabSelected = { tab ->
-                        // 現在選択中のタブと異なるタブが選択された場合のみ遷移
-                        if (tab != selectedTab) {
-                            previousTab = selectedTab
-                            selectedTab = tab
-                            when (tab) {
-                                0 -> navController.navigate("diary_list") {
-                                    popUpTo("diary_list") { inclusive = true }
-                                }
-                                1 -> navController.navigate("calendar") {
-                                    popUpTo("diary_list") { saveState = true }
-                                }
+                        previousTab = selectedTab
+                        selectedTab = tab
+                        when (tab) {
+                            0 -> navController.navigate("diary_list") {
+                                popUpTo("diary_list") { inclusive = true }
+                                launchSingleTop = true
+                            }
+                            1 -> navController.navigate("calendar") {
+                                popUpTo("diary_list") { saveState = true }
+                                launchSingleTop = true
                             }
                         }
                     },

--- a/app/src/main/java/net/chasmine/oneline/ui/components/CustomBottomBar.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/components/CustomBottomBar.kt
@@ -191,7 +191,8 @@ private fun SwarmTabItem(
             .clickable(
                 interactionSource = interactionSource,
                 indication = ripple(bounded = true, radius = 40.dp),
-                onClick = onClick
+                onClick = onClick,
+                enabled = !selected  // 選択中のタブはクリック無効化
             )
             .padding(vertical = 8.dp)
             .scale(scale),


### PR DESCRIPTION
## 概要
Issue #49 の修正です。ボトムナビゲーションで現在選択中のタブを連打した際に不要な画面遷移アニメーションが発生する問題を修正しました。

## 変更内容

### 🔄 リファクタリング済み（よりクリーンでエレガントな実装）

#### 1. **CustomBottomBar.kt - UI層でのタブ無効化**
```kotlin
.clickable(
    interactionSource = interactionSource,
    indication = ripple(bounded = true, radius = 40.dp),
    onClick = onClick,
    enabled = !selected  // 選択中のタブはクリック無効化
)
```
- `SwarmTabItem` の `clickable` に `enabled = !selected` を追加
- 選択中のタブはUI層で無効化され、クリック不可になります

#### 2. **MainActivity.kt - Navigation設定の最適化**
```kotlin
onTabSelected = { tab ->
    previousTab = selectedTab
    selectedTab = tab
    when (tab) {
        0 -> navController.navigate("diary_list") {
            popUpTo("diary_list") { inclusive = true }
            launchSingleTop = true  // 重複遷移防止
        }
        1 -> navController.navigate("calendar") {
            popUpTo("diary_list") { saveState = true }
            launchSingleTop = true  // 重複遷移防止
        }
    }
},
```
- 条件分岐を削除（UIコンポーネント側で制御するため不要に）
- `launchSingleTop = true` を追加し、Jetpack Navigationの標準機能で重複遷移を防止

## アーキテクチャの改善点

### ✅ メリット
1. **責任範囲の明確化**: UIコンポーネント（CustomBottomBar）が自身の状態を管理
2. **標準機能の活用**: Jetpack Navigationの `launchSingleTop` で堅牢性向上
3. **保守性の向上**: 条件分岐が不要になり、コードがよりクリーンに
4. **UI/UXの向上**: 選択中のタブは無効化されるため、ユーザーにも明確

### 📐 設計パターン
- **Single Responsibility Principle**: 各コンポーネントが適切な責任を持つ
- **Separation of Concerns**: UI層とNavigation層の責任を分離

## テスト
- [x] ビルドテスト成功
- [x] 実機での動作確認（日記タブを連打しても無反応）
- [x] 実機での動作確認（カレンダータブを連打しても無反応）
- [x] タブ切り替え時のアニメーションが正常に動作することを確認

## 影響範囲
- UI/ナビゲーション: ボトムナビゲーションのタブ選択ロジック
- コンポーネント設計: より明確な責任分離を実現

Fixes #49