### PR TITLE
設定画面の文字サイズと余白を改善 (#52)

### DIFF
--- a/app/src/main/java/net/chasmine/oneline/ui/components/NotificationSettingsSection.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/components/NotificationSettingsSection.kt
@@ -68,8 +68,8 @@ fun NotificationSettingsSection() {
         )
     ) {
         Column(
-            modifier = Modifier.padding(20.dp), // カード内の余白を増加
-            verticalArrangement = Arrangement.spacedBy(20.dp) // 要素間の余白を増加
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
             // 権限拒否時の案内
             if (showPermissionDeniedInfo) {
@@ -80,17 +80,17 @@ fun NotificationSettingsSection() {
                     )
                 ) {
                     Column(
-                        modifier = Modifier.padding(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        modifier = Modifier.padding(20.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         Text(
                             text = "⚠️ 通知権限が必要です",
-                            style = MaterialTheme.typography.titleSmall,
+                            style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.error
                         )
                         Text(
-                            text = "日記リマインダーを受け取るには、端末の設定から通知権限を有効にしてください。",
-                            style = MaterialTheme.typography.bodySmall,
+                            text = "端末の設定から通知権限を有効にしてください。",
+                            style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onErrorContainer
                         )
                         Button(
@@ -122,18 +122,18 @@ fun NotificationSettingsSection() {
                 Column(
                     modifier = Modifier
                         .weight(1f)
-                        .padding(end = 16.dp) // Switchとの間に適切な余白を確保
+                        .padding(end = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
                     Text(
                         text = "日記リマインダー",
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.padding(bottom = 4.dp)
+                        style = MaterialTheme.typography.titleLarge
                     )
                     Text(
-                        text = "毎日決まった時間に日記を書くリマインダーを受け取る",
-                        style = MaterialTheme.typography.bodySmall,
+                        text = "毎日決まった時間にリマインダーを受け取る",
+                        style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        lineHeight = MaterialTheme.typography.bodySmall.lineHeight
+                        lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
                     )
                 }
                 
@@ -172,10 +172,10 @@ fun NotificationSettingsSection() {
             // 時間設定
             if (isNotificationEnabled) {
                 HorizontalDivider(
-                    modifier = Modifier.padding(vertical = 8.dp),
+                    modifier = Modifier.padding(vertical = 12.dp),
                     color = MaterialTheme.colorScheme.outlineVariant
                 )
-                
+
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -192,23 +192,23 @@ fun NotificationSettingsSection() {
                                 true
                             ).show()
                         }
-                        .padding(vertical = 12.dp), // より適切な縦方向の余白
+                        .padding(vertical = 16.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Column(
                         modifier = Modifier
                             .weight(1f)
-                            .padding(end = 16.dp) // 時刻表示との間に余白を確保
+                            .padding(end = 20.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
                     ) {
                         Text(
                             text = "通知時刻",
-                            style = MaterialTheme.typography.titleMedium,
-                            modifier = Modifier.padding(bottom = 4.dp)
+                            style = MaterialTheme.typography.titleLarge
                         )
                         Text(
                             text = "タップして時刻を変更",
-                            style = MaterialTheme.typography.bodySmall,
+                            style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
@@ -232,7 +232,7 @@ fun NotificationSettingsSection() {
             // テスト通知ボタン（デバッグ用）
             if (isNotificationEnabled) {
                 HorizontalDivider(
-                    modifier = Modifier.padding(vertical = 8.dp),
+                    modifier = Modifier.padding(vertical = 12.dp),
                     color = MaterialTheme.colorScheme.outlineVariant
                 )
                 

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/AboutScreen.kt
@@ -83,17 +83,18 @@ fun AboutScreen(
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(16.dp)
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     Text(
                         text = "📖 OneLineについて",
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.primary
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
                     Text(
-                        text = "OneLineは、毎日の出来事を一行で記録するシンプルな日記アプリです。GitHubリポジトリと連携することで、あなたの日記を安全にバックアップし、どこからでもアクセスできます。",
-                        style = MaterialTheme.typography.bodyMedium
+                        text = "毎日の出来事を一行で記録するシンプルな日記アプリです。GitHubリポジトリと連携することで、安全にバックアップできます。",
+                        style = MaterialTheme.typography.bodyLarge,
+                        lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.3f
                     )
                 }
             }
@@ -106,15 +107,15 @@ fun AboutScreen(
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(16.dp)
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     Text(
                         text = "✨ 主な機能",
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.primary
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    
+
                     val features = listOf(
                         "📝 シンプルな日記作成・編集",
                         "📦 GitHubリポジトリとの自動同期",
@@ -122,12 +123,12 @@ fun AboutScreen(
                         "📱 ホーム画面ウィジェット",
                         "🔒 プライベートリポジトリ対応"
                     )
-                    
+
                     features.forEach { feature ->
                         Text(
                             text = feature,
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.padding(vertical = 2.dp)
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(vertical = 4.dp)
                         )
                     }
                 }
@@ -141,17 +142,18 @@ fun AboutScreen(
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(16.dp)
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     Text(
                         text = "👨‍💻 開発者",
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.primary
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
                     Text(
-                        text = "このアプリは個人開発プロジェクトです。\nフィードバックやご要望がございましたら、GitHubリポジトリまでお寄せください。",
-                        style = MaterialTheme.typography.bodyMedium
+                        text = "個人開発プロジェクトです。\nフィードバックやご要望はGitHubリポジトリまで。",
+                        style = MaterialTheme.typography.bodyLarge,
+                        lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.3f
                     )
                 }
             }
@@ -164,17 +166,18 @@ fun AboutScreen(
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(16.dp)
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     Text(
                         text = "📄 ライセンス",
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.primary
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
                     Text(
-                        text = "このアプリはオープンソースソフトウェアです。\n使用しているライブラリのライセンス情報については、GitHubリポジトリをご確認ください。",
-                        style = MaterialTheme.typography.bodyMedium
+                        text = "オープンソースソフトウェアです。\nライブラリのライセンス情報はGitHubリポジトリをご確認ください。",
+                        style = MaterialTheme.typography.bodyLarge,
+                        lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.3f
                     )
                 }
             }

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/DataStorageSettingsScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/DataStorageSettingsScreen.kt
@@ -70,38 +70,41 @@ fun DataStorageSettingsScreen(
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Text(
                         text = "現在の設定",
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold
                     )
                     
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         Icon(
                             imageVector = if (isLocalOnlyMode) Icons.Default.Phone else Icons.Default.Cloud,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(32.dp)
                         )
-                        
-                        Column {
+
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
                             Text(
                                 text = if (isLocalOnlyMode) "📱 ローカル保存のみ" else "☁️ Git連携",
-                                style = MaterialTheme.typography.titleSmall,
+                                style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold
                             )
                             Text(
                                 text = if (isLocalOnlyMode) {
-                                    "端末内にのみ保存されています"
+                                    "端末内にのみ保存"
                                 } else {
                                     "リポジトリ: ${gitRepoUrl.takeIf { it.isNotBlank() } ?: "未設定"}"
                                 },
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
@@ -112,7 +115,7 @@ fun DataStorageSettingsScreen(
             // 保存方法の選択
             Text(
                 text = "保存方法を選択",
-                style = MaterialTheme.typography.titleLarge,
+                style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold
             )
 
@@ -127,12 +130,12 @@ fun DataStorageSettingsScreen(
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         RadioButton(
                             selected = isLocalOnlyMode,
@@ -142,25 +145,29 @@ fun DataStorageSettingsScreen(
                                 }
                             }
                         )
-                        
-                        Column(modifier = Modifier.weight(1f)) {
+
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
                             Text(
                                 text = "📱 ローカル保存のみ",
-                                style = MaterialTheme.typography.titleMedium,
+                                style = MaterialTheme.typography.titleLarge,
                                 fontWeight = FontWeight.Bold
                             )
                             Text(
                                 text = "端末内にのみ保存",
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
                     }
-                    
+
                     Text(
-                        text = "✅ 設定不要ですぐに使用可能\n✅ プライベートで安全\n⚠️ バックアップや同期は手動\n⚠️ 端末紛失時にデータが失われる",
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(start = 48.dp)
+                        text = "✅ 設定不要\n✅ プライベート\n⚠️ バックアップは手動\n⚠️ 端末紛失時に失われる",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(start = 48.dp),
+                        lineHeight = MaterialTheme.typography.bodyMedium.lineHeight * 1.5f
                     )
                 }
             }
@@ -176,12 +183,12 @@ fun DataStorageSettingsScreen(
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         RadioButton(
                             selected = !isLocalOnlyMode,
@@ -192,24 +199,28 @@ fun DataStorageSettingsScreen(
                             }
                         )
                         
-                        Column(modifier = Modifier.weight(1f)) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
                             Text(
                                 text = "☁️ Git連携",
-                                style = MaterialTheme.typography.titleMedium,
+                                style = MaterialTheme.typography.titleLarge,
                                 fontWeight = FontWeight.Bold
                             )
                             Text(
                                 text = "クラウドで自動バックアップ",
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
                     }
                     
                     Text(
-                        text = "✅ 自動バックアップ\n✅ 複数端末での同期\n✅ バージョン管理\n⚠️ GitHubなどの設定が必要",
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(start = 48.dp)
+                        text = "✅ 自動バックアップ\n✅ 複数端末で同期\n✅ バージョン管理\n⚠️ Git設定が必要",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(start = 48.dp),
+                        lineHeight = MaterialTheme.typography.bodyMedium.lineHeight * 1.5f
                     )
                     
                     if (!isLocalOnlyMode && gitRepoUrl.isBlank()) {
@@ -219,18 +230,19 @@ fun DataStorageSettingsScreen(
                             )
                         ) {
                             Row(
-                                modifier = Modifier.padding(12.dp),
+                                modifier = Modifier.padding(16.dp),
                                 verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                horizontalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.Warning,
                                     contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.error
+                                    tint = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.size(24.dp)
                                 )
                                 Text(
                                     text = "Git設定が必要です",
-                                    style = MaterialTheme.typography.bodySmall,
+                                    style = MaterialTheme.typography.bodyMedium,
                                     color = MaterialTheme.colorScheme.onErrorContainer
                                 )
                             }

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/GitSettingsScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/GitSettingsScreen.kt
@@ -135,17 +135,17 @@ fun GitSettingsScreen(
                         )
                     ) {
                         Column(
-                            modifier = Modifier.padding(16.dp)
+                            modifier = Modifier.padding(24.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             Text(
                                 text = "💡 重要",
-                                style = MaterialTheme.typography.titleSmall,
+                                style = MaterialTheme.typography.titleMedium,
                                 color = MaterialTheme.colorScheme.primary
                             )
-                            Spacer(modifier = Modifier.height(8.dp))
                             Text(
-                                text = "日記専用のリポジトリを使用してください。既存のプロジェクトリポジトリは使用しないでください。",
-                                style = MaterialTheme.typography.bodySmall
+                                text = "日記専用のリポジトリを使用してください。",
+                                style = MaterialTheme.typography.bodyMedium
                             )
                         }
                     }
@@ -153,25 +153,28 @@ fun GitSettingsScreen(
                     // Git設定フォーム
                     OutlinedTextField(
                         value = repoUrl,
-                        onValueChange = { 
+                        onValueChange = {
                             repoUrl = it
                             isValidationPassed = false
                         },
-                        label = { Text("日記リポジトリURL") },
+                        label = { Text("日記リポジトリURL", style = MaterialTheme.typography.bodyLarge) },
                         placeholder = { Text("https://github.com/username/my-diary.git") },
                         modifier = Modifier.fillMaxWidth(),
                         supportingText = {
-                            Text("日記データを保存するGitHubリポジトリのURLを入力してください")
+                            Text(
+                                "日記データを保存するGitHubリポジトリのURL",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
                         }
                     )
 
                     OutlinedTextField(
                         value = username,
-                        onValueChange = { 
+                        onValueChange = {
                             username = it
                             isValidationPassed = false
                         },
-                        label = { Text("ユーザー名") },
+                        label = { Text("ユーザー名", style = MaterialTheme.typography.bodyLarge) },
                         modifier = Modifier.fillMaxWidth()
                     )
 
@@ -181,7 +184,7 @@ fun GitSettingsScreen(
                             token = it
                             isValidationPassed = false
                         },
-                        label = { Text("アクセストークン") },
+                        label = { Text("アクセストークン", style = MaterialTheme.typography.bodyLarge) },
                         visualTransformation = PasswordVisualTransformation(),
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -194,17 +197,17 @@ fun GitSettingsScreen(
                         )
                     ) {
                         Column(
-                            modifier = Modifier.padding(16.dp),
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                            modifier = Modifier.padding(24.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             Text(
                                 text = "📝 コミット情報",
-                                style = MaterialTheme.typography.titleSmall,
+                                style = MaterialTheme.typography.titleMedium,
                                 color = MaterialTheme.colorScheme.primary
                             )
                             Text(
-                                text = "GitHubのコントリビュート履歴に正しく記録されるよう、コミット時に使用するユーザー名とメールアドレスを設定してください。",
-                                style = MaterialTheme.typography.bodySmall,
+                                text = "コミット時に使用するユーザー名とメールアドレスを設定してください。",
+                                style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
@@ -213,22 +216,28 @@ fun GitSettingsScreen(
                     OutlinedTextField(
                         value = commitUserName,
                         onValueChange = { commitUserName = it },
-                        label = { Text("コミット用ユーザー名") },
+                        label = { Text("コミット用ユーザー名", style = MaterialTheme.typography.bodyLarge) },
                         placeholder = { Text("例: Taro Yamada") },
                         modifier = Modifier.fillMaxWidth(),
                         supportingText = {
-                            Text("GitHubのコミット履歴に表示される名前")
+                            Text(
+                                "GitHubのコミット履歴に表示される名前",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
                         }
                     )
 
                     OutlinedTextField(
                         value = commitUserEmail,
                         onValueChange = { commitUserEmail = it },
-                        label = { Text("コミット用メールアドレス") },
+                        label = { Text("コミット用メールアドレス", style = MaterialTheme.typography.bodyLarge) },
                         placeholder = { Text("例: taro@example.com") },
                         modifier = Modifier.fillMaxWidth(),
                         supportingText = {
-                            Text("GitHubアカウントに登録されているメールアドレスを推奨")
+                            Text(
+                                "GitHubアカウントに登録されているメールアドレス",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
                         }
                     )
 

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/MainSettingsScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/MainSettingsScreen.kt
@@ -56,7 +56,7 @@ fun MainSettingsScreen(
                 .fillMaxSize()
                 .padding(paddingValues),
             contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             item {
                 SettingsSection(title = "表示") {
@@ -162,9 +162,9 @@ fun SettingsSection(
     Column {
         Text(
             text = title,
-            style = MaterialTheme.typography.titleSmall,
+            style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
         )
         Card(
             modifier = Modifier.fillMaxWidth(),
@@ -188,35 +188,38 @@ fun SettingsItem(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick() }
-            .padding(16.dp),
+            .padding(20.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             imageVector = icon,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(24.dp)
+            modifier = Modifier.size(28.dp)
         )
-        
-        Spacer(modifier = Modifier.width(16.dp))
-        
-        Column(modifier = Modifier.weight(1f)) {
+
+        Spacer(modifier = Modifier.width(20.dp))
+
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
             Text(
                 text = title,
-                style = MaterialTheme.typography.titleMedium
+                style = MaterialTheme.typography.titleLarge
             )
             Text(
                 text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
+                style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        
+
         Icon(
             imageVector = Icons.AutoMirrored.Filled.ArrowForward,
             contentDescription = "進む",
             tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-            modifier = Modifier.size(20.dp)
+            modifier = Modifier.size(24.dp)
         )
     }
 }

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/NotificationSettingsScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/NotificationSettingsScreen.kt
@@ -45,18 +45,18 @@ fun NotificationSettingsScreen(
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(20.dp), // カード内の余白を増加
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     Text(
                         text = "🔔 通知について",
-                        style = MaterialTheme.typography.titleSmall,
+                        style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.primary
                     )
                     Text(
-                        text = "毎日決まった時間に日記を書くリマインダーを受け取ることができます。既に日記を書いている場合は通知されません。",
-                        style = MaterialTheme.typography.bodySmall,
-                        lineHeight = MaterialTheme.typography.bodySmall.lineHeight
+                        text = "毎日決まった時間に日記を書くリマインダーを受け取れます。",
+                        style = MaterialTheme.typography.bodyMedium,
+                        lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
                     )
                 }
             }
@@ -74,19 +74,19 @@ fun NotificationSettingsScreen(
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(20.dp), // カード内の余白を増加
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     Text(
                         text = "⚠️ 注意事項",
-                        style = MaterialTheme.typography.titleSmall,
+                        style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.error
                     )
                     Text(
-                        text = "• Android 13以降では通知権限の許可が必要です\n• バッテリー最適化の設定により通知が遅延する場合があります\n• 端末の省電力モードでは通知が制限される場合があります",
-                        style = MaterialTheme.typography.bodySmall,
+                        text = "• Android 13以降では通知権限の許可が必要です\n• バッテリー最適化により通知が遅延する場合があります\n• 省電力モードでは通知が制限される場合があります",
+                        style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        lineHeight = MaterialTheme.typography.bodySmall.lineHeight
+                        lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
                     )
                 }
             }


### PR DESCRIPTION
## 概要
issue #52 に対応し、設定画面全般の視認性を大幅に向上させました。

## 変更内容

### 文字サイズの改善
- **タイトル**: `titleSmall` → `titleMedium`/`titleLarge`
- **本文**: `bodySmall` → `bodyMedium`/`bodyLarge`
- **ラベル**: `bodyMedium` → `bodyLarge`

### 余白の改善
- **カード内のpadding**: 16dp/20dp → 24dp
- **要素間のspacing**: 8dp/12dp → 12dp/16dp/20dp/24dp
- **アイコンサイズ**: 24dp → 28dp/32dp

### テキストの洗練
- 冗長な説明文を簡潔に整理
- 行間を適切に調整（lineHeight調整）
- 不必要に長い文言を短縮

## 対象画面
1. **MainSettingsScreen**: セクションタイトルと設定項目
2. **NotificationSettingsScreen**: 説明カードと注意事項
3. **NotificationSettingsSection**: 設定項目とテスト通知ボタン
4. **DataStorageSettingsScreen**: 現在の設定と保存方法選択
5. **GitSettingsScreen**: 説明カードとフォームラベル
6. **AboutScreen**: アプリ説明と機能一覧

## テスト
- [x] ビルド成功
- [x] 全画面で文字サイズと余白が適切に改善されているか確認

## 影響範囲
- UI/設定画面: 視認性向上
- テキスト: 簡潔化

Closes #52