### PR TITLE
Material Design 3準拠のアラートダイアログに更新 #54

### DIFF
--- a/app/src/main/java/net/chasmine/oneline/ui/components/AlertComponents.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/components/AlertComponents.kt
@@ -1,0 +1,160 @@
+package net.chasmine.oneline.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+enum class AlertType {
+    SUCCESS,
+    ERROR,
+    WARNING,
+    INFO
+}
+
+@Composable
+fun MaterialAlertDialog(
+    onDismissRequest: () -> Unit,
+    title: String,
+    message: String,
+    alertType: AlertType = AlertType.INFO,
+    confirmText: String = "OK",
+    onConfirmClick: () -> Unit = onDismissRequest,
+    dismissText: String? = null,
+    onDismissClick: (() -> Unit)? = null
+) {
+    val icon = when (alertType) {
+        AlertType.SUCCESS -> Icons.Default.CheckCircle
+        AlertType.ERROR -> Icons.Default.Error
+        AlertType.WARNING -> Icons.Default.Warning
+        AlertType.INFO -> Icons.Default.Info
+    }
+
+    val iconTint = when (alertType) {
+        AlertType.SUCCESS -> Color(0xFF4CAF50)
+        AlertType.ERROR -> MaterialTheme.colorScheme.error
+        AlertType.WARNING -> Color(0xFFFF9800)
+        AlertType.INFO -> MaterialTheme.colorScheme.primary
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        icon = {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = iconTint,
+                modifier = Modifier.size(28.dp)
+            )
+        },
+        title = {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall
+            )
+        },
+        text = {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirmClick) {
+                Text(confirmText)
+            }
+        },
+        dismissButton = if (dismissText != null && onDismissClick != null) {
+            {
+                TextButton(onClick = onDismissClick) {
+                    Text(dismissText)
+                }
+            }
+        } else null
+    )
+}
+
+@Composable
+fun InfoCard(
+    message: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector = Icons.Default.Info,
+    containerColor: Color = MaterialTheme.colorScheme.primaryContainer,
+    contentColor: Color = MaterialTheme.colorScheme.onPrimaryContainer
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = containerColor,
+            contentColor = contentColor
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+fun SuccessCard(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    InfoCard(
+        message = message,
+        modifier = modifier,
+        icon = Icons.Default.CheckCircle,
+        containerColor = Color(0xFFE8F5E9),
+        contentColor = Color(0xFF2E7D32)
+    )
+}
+
+@Composable
+fun ErrorCard(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    InfoCard(
+        message = message,
+        modifier = modifier,
+        icon = Icons.Default.Error,
+        containerColor = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer
+    )
+}
+
+@Composable
+fun WarningCard(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    InfoCard(
+        message = message,
+        modifier = modifier,
+        icon = Icons.Default.Warning,
+        containerColor = Color(0xFFFFF3E0),
+        contentColor = Color(0xFFE65100)
+    )
+}

--- a/app/src/main/java/net/chasmine/oneline/ui/components/NotificationSettingsSection.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/components/NotificationSettingsSection.kt
@@ -84,7 +84,7 @@ fun NotificationSettingsSection() {
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Text(
-                            text = "⚠️ 通知権限が必要です",
+                            text = "通知権限が必要です",
                             style = MaterialTheme.typography.titleSmall,
                             color = MaterialTheme.colorScheme.error
                         )

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/DataStorageSettingsScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/DataStorageSettingsScreen.kt
@@ -138,13 +138,13 @@ fun DataStorageSettingsScreen(
 
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                text = "📱 ローカル保存のみ",
+                                text = "ローカル保存のみ",
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold
                             )
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
-                                text = "✅ 設定不要ですぐ使える\n✅ 完全プライベート\n⚠️ 端末紛失でデータ消失",
+                                text = "• 設定不要ですぐ使える\n• 完全プライベート\n• 端末紛失でデータ消失のリスク",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
@@ -188,13 +188,13 @@ fun DataStorageSettingsScreen(
 
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                text = "☁️ Git連携",
+                                text = "Git連携",
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold
                             )
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
-                                text = "✅ 自動バックアップ\n✅ 複数端末で同期\n⚠️ GitHubの設定が必要",
+                                text = "• 自動バックアップ\n• 複数端末で同期\n• GitHubの設定が必要",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/GitSettingsScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/GitSettingsScreen.kt
@@ -17,6 +17,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import net.chasmine.oneline.ui.viewmodels.SettingsViewModel
 import net.chasmine.oneline.data.preferences.SettingsManager
 import net.chasmine.oneline.data.repository.RepositoryManager
+import net.chasmine.oneline.ui.components.MaterialAlertDialog
+import net.chasmine.oneline.ui.components.AlertType
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -247,9 +249,9 @@ fun GitSettingsScreen(
                             Spacer(modifier = Modifier.width(8.dp))
                             Text("検証中...")
                         } else if (isValidationPassed) {
-                            Text("✅ 検証済み - 再検証")
+                            Text("検証済み - 再検証")
                         } else {
-                            Text("🔍 リポジトリを検証")
+                            Text("リポジトリを検証")
                         }
                     }
 
@@ -279,9 +281,9 @@ fun GitSettingsScreen(
                     ) {
                         if (isValidationPassed) {
                             if (isLocalOnlyMode) {
-                                Text("✅ Git連携に移行して保存")
+                                Text("Git連携に移行して保存")
                             } else {
-                                Text("✅ 設定を保存")
+                                Text("設定を保存")
                             }
                         } else {
                             Text("リポジトリを検証")
@@ -295,71 +297,62 @@ fun GitSettingsScreen(
         
         // 成功ダイアログ
         if (showSuccessDialog) {
-            AlertDialog(
+            MaterialAlertDialog(
                 onDismissRequest = { showSuccessDialog = false },
-                title = { Text("✅ 設定完了") },
-                text = { Text("Git設定が正常に保存されました。") },
-                confirmButton = {
-                    TextButton(onClick = { showSuccessDialog = false }) {
-                        Text("OK")
-                    }
-                }
+                title = "設定完了",
+                message = "Git設定が正常に保存されました。",
+                alertType = AlertType.SUCCESS
             )
         }
 
         // エラーダイアログ
         if (showErrorDialog) {
-            AlertDialog(
+            MaterialAlertDialog(
                 onDismissRequest = { showErrorDialog = false },
-                title = { Text("❌ エラー") },
-                text = { Text(errorMessage) },
-                confirmButton = {
-                    TextButton(onClick = { showErrorDialog = false }) {
-                        Text("OK")
-                    }
-                }
+                title = "エラー",
+                message = errorMessage,
+                alertType = AlertType.ERROR
             )
         }
 
         // 検証結果ダイアログ
         if (showValidationDialog) {
-            AlertDialog(
+            val dialogAlertType = when (validationResult) {
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.DIARY_REPOSITORY,
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.LIKELY_DIARY_REPOSITORY,
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.EMPTY_REPOSITORY -> AlertType.SUCCESS
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.UNKNOWN_REPOSITORY -> AlertType.WARNING
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.SUSPICIOUS_REPOSITORY,
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.DANGEROUS_REPOSITORY,
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.OWNERSHIP_VERIFICATION_FAILED,
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.AUTHENTICATION_FAILED,
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.REPOSITORY_NOT_FOUND,
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.CONNECTION_FAILED,
+                net.chasmine.oneline.data.git.GitRepository.ValidationResult.VALIDATION_FAILED -> AlertType.ERROR
+                else -> AlertType.INFO
+            }
+            
+            MaterialAlertDialog(
                 onDismissRequest = { showValidationDialog = false },
-                title = { Text("リポジトリ検証結果") },
-                text = { Text(validationMessage) },
-                confirmButton = {
-                    TextButton(onClick = { showValidationDialog = false }) {
-                        Text("OK")
-                    }
-                }
+                title = "リポジトリ検証結果",
+                message = validationMessage,
+                alertType = dialogAlertType
             )
         }
 
         // ヘルプダイアログ
         if (showCreateRepoHelpDialog) {
-            AlertDialog(
+            MaterialAlertDialog(
                 onDismissRequest = { showCreateRepoHelpDialog = false },
-                title = { Text("📖 日記リポジトリの設定ガイド") },
-                text = {
-                    Column(
-                        modifier = Modifier.verticalScroll(rememberScrollState())
-                    ) {
-                        Text(
-                            text = "GitHubで日記専用のプライベートリポジトリを作成してください。",
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = "1. GitHubにログインし、新しいリポジトリを作成\n2. リポジトリ名を設定（例: my-diary）\n3. プライベートリポジトリに設定\n4. READMEファイルで初期化\n5. Personal Access Tokenを作成",
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                },
-                confirmButton = {
-                    TextButton(onClick = { showCreateRepoHelpDialog = false }) {
-                        Text("閉じる")
-                    }
-                }
+                title = "日記リポジトリの設定ガイド",
+                message = "GitHubで日記専用のプライベートリポジトリを作成してください。\n\n" +
+                        "1. GitHubにログインし、新しいリポジトリを作成\n" +
+                        "2. リポジトリ名を設定（例: my-diary）\n" +
+                        "3. プライベートリポジトリに設定\n" +
+                        "4. READMEファイルで初期化\n" +
+                        "5. Personal Access Tokenを作成",
+                alertType = AlertType.INFO,
+                confirmText = "閉じる"
             )
         }
         

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/NotificationSettingsScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/NotificationSettingsScreen.kt
@@ -3,12 +3,16 @@ package net.chasmine.oneline.ui.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import net.chasmine.oneline.ui.components.NotificationSettingsSection
+import net.chasmine.oneline.ui.components.InfoCard
+import net.chasmine.oneline.ui.components.WarningCard
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -34,32 +38,14 @@ fun NotificationSettingsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(horizontal = 16.dp, vertical = 8.dp), // より適切な余白設定
-            verticalArrangement = Arrangement.spacedBy(20.dp) // カード間の余白を増加
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             // 説明カード
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer
-                )
-            ) {
-                Column(
-                    modifier = Modifier.padding(20.dp), // カード内の余白を増加
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text(
-                        text = "🔔 通知について",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    Text(
-                        text = "毎日決まった時間に日記を書くリマインダーを受け取ることができます。既に日記を書いている場合は通知されません。",
-                        style = MaterialTheme.typography.bodySmall,
-                        lineHeight = MaterialTheme.typography.bodySmall.lineHeight
-                    )
-                }
-            }
+            InfoCard(
+                message = "毎日決まった時間に日記を書くリマインダーを受け取ることができます。既に日記を書いている場合は通知されません。",
+                modifier = Modifier.fillMaxWidth()
+            )
 
             // 通知設定セクション
             NotificationSettingsSection()
@@ -67,29 +53,10 @@ fun NotificationSettingsScreen(
             Spacer(modifier = Modifier.weight(1f))
 
             // 注意事項
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                )
-            ) {
-                Column(
-                    modifier = Modifier.padding(20.dp), // カード内の余白を増加
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text(
-                        text = "⚠️ 注意事項",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.error
-                    )
-                    Text(
-                        text = "• Android 13以降では通知権限の許可が必要です\n• バッテリー最適化の設定により通知が遅延する場合があります\n• 端末の省電力モードでは通知が制限される場合があります",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        lineHeight = MaterialTheme.typography.bodySmall.lineHeight
-                    )
-                }
-            }
+            WarningCard(
+                message = "• Android 13以降では通知権限の許可が必要です\n• バッテリー最適化の設定により通知が遅延する場合があります\n• 端末の省電力モードでは通知が制限される場合があります",
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }

--- a/app/src/main/java/net/chasmine/oneline/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/screens/WelcomeScreen.kt
@@ -306,13 +306,13 @@ private fun DataStorageSelectionPage(
 
                         Column {
                             Text(
-                                text = "📱 ローカル保存のみ（推奨）",
+                                text = "ローカル保存のみ（推奨）",
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold
                             )
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
-                                text = "✅ 設定不要ですぐ使える\n✅ 完全プライベート",
+                                text = "• 設定不要ですぐ使える\n• 完全プライベート",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
@@ -347,13 +347,13 @@ private fun DataStorageSelectionPage(
 
                         Column {
                             Text(
-                                text = "☁️ Git連携",
+                                text = "Git連携",
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold
                             )
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
-                                text = "✅ 自動バックアップ\n✅ 複数端末で同期",
+                                text = "• 自動バックアップ\n• 複数端末で同期",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )

--- a/app/src/main/java/net/chasmine/oneline/ui/viewmodels/SettingViewModel.kt
+++ b/app/src/main/java/net/chasmine/oneline/ui/viewmodels/SettingViewModel.kt
@@ -90,27 +90,27 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 
                 val message = when (validationResult) {
                     GitRepository.ValidationResult.DIARY_REPOSITORY -> 
-                        "✅ 日記リポジトリとして最適です。\n\n日記形式のMarkdownファイル（YYYY-MM-DD.md）が確認されました。安全に使用できます。"
+                        "日記リポジトリとして最適です。\n\n日記形式のMarkdownファイル（YYYY-MM-DD.md）が確認されました。安全に使用できます。"
                     GitRepository.ValidationResult.LIKELY_DIARY_REPOSITORY -> 
-                        "✅ 日記用リポジトリとして適切です。\n\nリポジトリ名またはMarkdownファイルから日記用途として判定されました。安全に使用できます。"
+                        "日記用リポジトリとして適切です。\n\nリポジトリ名またはMarkdownファイルから日記用途として判定されました。安全に使用できます。"
                     GitRepository.ValidationResult.EMPTY_REPOSITORY -> 
-                        "✅ 空のリポジトリです。\n\n新しい日記リポジトリとして使用できます。初回同期時に日記ファイルが作成されます。"
+                        "空のリポジトリです。\n\n新しい日記リポジトリとして使用できます。初回同期時に日記ファイルが作成されます。"
                     GitRepository.ValidationResult.UNKNOWN_REPOSITORY -> 
-                        "⚠️ 内容が不明なリポジトリです。\n\nリポジトリ名とファイル内容から用途を判定できませんでした。使用前にGitHub上で内容を確認することを推奨します。\n\n推奨: 「my-diary」「daily-notes」などの分かりやすい名前のリポジトリを作成してください。"
+                        "内容が不明なリポジトリです。\n\nリポジトリ名とファイル内容から用途を判定できませんでした。使用前にGitHub上で内容を確認することを推奨します。\n\n推奨: 「my-diary」「daily-notes」などの分かりやすい名前のリポジトリを作成してください。"
                     GitRepository.ValidationResult.SUSPICIOUS_REPOSITORY -> 
-                        "❌ 危険: 開発用リポジトリの可能性があります。\n\nリポジトリ名から開発用途と判定されました。日記用には使用しないでください。\n\n推奨: 新しく日記専用のリポジトリを作成してください。\n例: 「my-diary-2025」「daily-journal」など"
+                        "危険: 開発用リポジトリの可能性があります。\n\nリポジトリ名から開発用途と判定されました。日記用には使用しないでください。\n\n推奨: 新しく日記専用のリポジトリを作成してください。\n例: 「my-diary-2025」「daily-journal」など"
                     GitRepository.ValidationResult.DANGEROUS_REPOSITORY -> 
-                        "❌ 危険: 開発用リポジトリです。\n\nコードファイル（.kt, .java, .gradle等）が確認されました。このリポジトリは絶対に使用しないでください。\n\n推奨: 新しく日記専用のリポジトリを作成してください。"
+                        "危険: 開発用リポジトリです。\n\nコードファイル（.kt, .java, .gradle等）が確認されました。このリポジトリは絶対に使用しないでください。\n\n推奨: 新しく日記専用のリポジトリを作成してください。"
                     GitRepository.ValidationResult.OWNERSHIP_VERIFICATION_FAILED -> 
-                        "🚨 セキュリティ警告: リポジトリ所有者確認に失敗しました。\n\nこのリポジトリはあなたが所有していない可能性があります。他人のリポジトリに日記を投稿することは以下のリスクがあります：\n\n• プライバシーの侵害\n• 不正なデータ投稿\n• アカウントの悪用\n\n必ず自分が所有するリポジトリのみを使用してください。"
+                        "セキュリティ警告: リポジトリ所有者確認に失敗しました。\n\nこのリポジトリはあなたが所有していない可能性があります。他人のリポジトリに日記を投稿することは以下のリスクがあります：\n\n• プライバシーの侵害\n• 不正なデータ投稿\n• アカウントの悪用\n\n必ず自分が所有するリポジトリのみを使用してください。"
                     GitRepository.ValidationResult.AUTHENTICATION_FAILED -> 
-                        "❌ 認証に失敗しました。\n\n以下を確認してください:\n• ユーザー名が正しいか\n• アクセストークンが有効か\n• トークンにリポジトリへの読み書き権限があるか"
+                        "認証に失敗しました。\n\n以下を確認してください:\n• ユーザー名が正しいか\n• アクセストークンが有効か\n• トークンにリポジトリへの読み書き権限があるか"
                     GitRepository.ValidationResult.REPOSITORY_NOT_FOUND -> 
-                        "❌ リポジトリが見つかりません。\n\n以下を確認してください:\n• URLが正しいか\n• リポジトリが存在するか\n• プライベートリポジトリの場合、アクセス権限があるか"
+                        "リポジトリが見つかりません。\n\n以下を確認してください:\n• URLが正しいか\n• リポジトリが存在するか\n• プライベートリポジトリの場合、アクセス権限があるか"
                     GitRepository.ValidationResult.CONNECTION_FAILED -> 
-                        "❌ リポジトリに接続できませんでした。\n\n以下を確認してください:\n• インターネット接続\n• GitHubのサービス状況\n• ファイアウォール設定"
+                        "リポジトリに接続できませんでした。\n\n以下を確認してください:\n• インターネット接続\n• GitHubのサービス状況\n• ファイアウォール設定"
                     GitRepository.ValidationResult.VALIDATION_FAILED -> 
-                        "❌ 検証に失敗しました。\n\n設定を確認して再度お試しください。問題が続く場合は、新しいリポジトリの作成を検討してください。"
+                        "検証に失敗しました。\n\n設定を確認して再度お試しください。問題が続く場合は、新しいリポジトリの作成を検討してください。"
                 }
                 
                 _uiState.value = UiState.ValidationResult(


### PR DESCRIPTION
## 概要
Issue #54 の対応です。絵文字を使用したカード型UIをMaterial Design 3の標準コンポーネントに置き換えました。

## 変更内容

### 新規ファイル
- `AlertComponents.kt`: Material 3準拠のアラートコンポーネントを提供
  - `MaterialAlertDialog`: アイコン付きアラートダイアログ
  - `InfoCard`, `ErrorCard`, `WarningCard`, `SuccessCard`: 情報表示用カード

### 主な変更
1. **アラートダイアログの改善**
   - 絵文字（✅、❌、⚠️、🚨）をMaterial Iconsに置き換え
   - アラートタイプ（SUCCESS、ERROR、WARNING、INFO）に応じた適切なアイコンと色を使用
   - より視認性の高いデザインに変更

2. **更新したファイル**
   - `GitSettingsScreen.kt`: ダイアログとボタンテキストから絵文字を削除
   - `SettingViewModel.kt`: 検証メッセージから絵文字を削除
   - `NotificationSettingsScreen.kt`: InfoCardとWarningCardを使用
   - `DataStorageSettingsScreen.kt`: 説明テキストから絵文字を削除
   - `WelcomeScreen.kt`: 選択肢の説明から絵文字を削除
   - `NotificationSettingsSection.kt`: 警告テキストから絵文字を削除

## テスト
- ビルド成功を確認
- 全テストパス

## スクリーンショット
（必要に応じて追加）

Closes #54